### PR TITLE
Added fix for the spacing issue.

### DIFF
--- a/oreo.py
+++ b/oreo.py
@@ -7,47 +7,53 @@ from fuzzywuzzy import process
 mydict = SqliteDict('./my_db.sqlite', autocommit=True)
 
 load_dotenv()
-lwe={}
+lwe = {}
 TOKEN = os.getenv('DISCORD_TOKEN')
 
 client = discord.Client()
+
 
 @client.event
 async def on_ready():
     print(f'{client.user} has connected to Discord!')
 
+
 @client.event
 async def on_message(message):
-    cnt=1
+    cnt = 1
     if message.content.startswith("!coreo"):
-        if len(message.content)<8:
+        if len(message.content) < 8:
             return
         xo = message.content[7:]
-        x=''
+        x = ''
         channelList = []
         channelmention = {}
-        for channel in  message.guild.channels:
+        for channel in message.guild.channels:
             if type(channel) != discord.channel.TextChannel:
                 continue
             channelList.append(channel.name)
             channelmention[channel.name] = channel.mention
-        for channel,weight in process.extract(xo, channelList):
-            x += (f"{cnt} {channel}  {str(weight)} {channelmention[channel]}\n")
-            cnt+=1
-        if len(x)>0:
-            sent=await message.channel.send(x)
+        for channel, weight in process.extract(xo, channelList):
+            x += (
+                f"{cnt} {channel}  {str(weight)} {channelmention[channel]}\n")
+            cnt += 1
+        if len(x) > 0:
+            sent = await message.channel.send(x)
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id]=xo
+            mydict[sent.id] = xo
         else:
-            sent=await message.channel.send(f"No results. Hit like to create channel '{xo}'.")
+            sent = await message.channel.send(f"No results. Hit like to create channel '{xo}'.")
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id]=xo
+            mydict[sent.id] = xo
+
 
 @client.event
 async def on_reaction_add(reaction, user):
     if user.bot:
         return
     if reaction.message.id not in mydict:
+        return
+    if user.id != reaction.message.author.id:
         return
     await reaction.message.guild.create_text_channel(mydict[reaction.message.id])
 

--- a/oreo.py
+++ b/oreo.py
@@ -25,6 +25,7 @@ async def on_message(message):
         if len(message.content) < 8:
             return
         xo = message.content[7:]
+        author_id = message.author.id
         x = ''
         channelList = []
         channelmention = {}
@@ -40,11 +41,11 @@ async def on_message(message):
         if len(x) > 0:
             sent = await message.channel.send(x)
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = xo
+            mydict[sent.id] = tuple([xo, author_id])
         else:
             sent = await message.channel.send(f"No results. Hit like to create channel '{xo}'.")
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = xo
+            mydict[sent.id] = tuple([xo, author_id])
 
 
 @client.event
@@ -53,8 +54,8 @@ async def on_reaction_add(reaction, user):
         return
     if reaction.message.id not in mydict:
         return
-    if user.id != reaction.message.author.id:
+    if user.id != mydict[reaction.message.id][1]:
         return
-    await reaction.message.guild.create_text_channel(mydict[reaction.message.id])
+    await reaction.message.guild.create_text_channel(mydict[reaction.message.id][0])
 
 client.run(TOKEN)

--- a/oreo.py
+++ b/oreo.py
@@ -21,32 +21,39 @@ async def on_ready():
 @client.event
 async def on_message(message):
     cnt = 1
-    if message.content.startswith("!coreo"):
+    if message.content.startswith("!coreo "):
         if len(message.content) < 8:
             return
         xo = message.content[7:]
-        author_id = message.author.id
-        x = ''
-        channelList = []
-        channelmention = {}
-        for channel in message.guild.channels:
-            if type(channel) != discord.channel.TextChannel:
-                continue
-            channelList.append(channel.name)
-            channelmention[channel.name] = channel.mention
-        for channel, weight in process.extract(xo, channelList):
-            if weight > 0:
-                x += (
-                    f"{cnt} {channel}  {str(weight)} {channelmention[channel]}\n")
-                cnt += 1
-        if len(x) > 0:
-            sent = await message.channel.send(x)
-            await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = tuple([xo, author_id, False])
-        else:
-            sent = await message.channel.send(f"No results. Hit like to create channel '{xo}'.")
-            await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = tuple([xo, author_id, False])
+    elif message.content.startswith("!coreo"):
+        if len(message.content) < 7:
+            return
+        xo = message.content[6:]
+    else:
+        return
+    author_id = message.author.id
+    x = '**Channel List**\n'
+    channelList = []
+    channelmention = {}
+    for channel in message.guild.channels:
+        if type(channel) != discord.channel.TextChannel:
+            continue
+        channelList.append(channel.name)
+        channelmention[channel.name] = channel.mention
+    for channel, weight in process.extract(xo, channelList):
+        if weight > 0:
+            x += (
+                f"> {channelmention[channel]}\n")
+            cnt += 1
+    if len(x) > 0:
+        x += f"**Hit like to create channel '*{xo}*'**"
+        sent = await message.channel.send(x)
+        await sent.add_reaction('\N{THUMBS UP SIGN}')
+        mydict[sent.id] = list([xo, author_id, False])
+    else:
+        sent = await message.channel.send(f"**No results. Hit like to create channel '*{xo}*'.**")
+        await sent.add_reaction('\N{THUMBS UP SIGN}')
+        mydict[sent.id] = list([xo, author_id, False])
 
 
 @client.event

--- a/oreo.py
+++ b/oreo.py
@@ -41,11 +41,11 @@ async def on_message(message):
         if len(x) > 0:
             sent = await message.channel.send(x)
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = tuple([xo, author_id])
+            mydict[sent.id] = tuple([xo, author_id, False])
         else:
             sent = await message.channel.send(f"No results. Hit like to create channel '{xo}'.")
             await sent.add_reaction('\N{THUMBS UP SIGN}')
-            mydict[sent.id] = tuple([xo, author_id])
+            mydict[sent.id] = tuple([xo, author_id, False])
 
 
 @client.event
@@ -56,6 +56,9 @@ async def on_reaction_add(reaction, user):
         return
     if user.id != mydict[reaction.message.id][1]:
         return
+    if mydict[reaction.message.id][2]:
+        return
+    mydict[reaction.message.id][2] = True
     await reaction.message.guild.create_text_channel(mydict[reaction.message.id][0])
 
 client.run(TOKEN)

--- a/oreo.py
+++ b/oreo.py
@@ -35,9 +35,10 @@ async def on_message(message):
             channelList.append(channel.name)
             channelmention[channel.name] = channel.mention
         for channel, weight in process.extract(xo, channelList):
-            x += (
-                f"{cnt} {channel}  {str(weight)} {channelmention[channel]}\n")
-            cnt += 1
+            if weight > 0:
+                x += (
+                    f"{cnt} {channel}  {str(weight)} {channelmention[channel]}\n")
+                cnt += 1
         if len(x) > 0:
             sent = await message.channel.send(x)
             await sent.add_reaction('\N{THUMBS UP SIGN}')


### PR DESCRIPTION
Now if you run it as `!coreo 777` or `!coreo777` in both cases the channel name to be searched/ made is **777**.
Do test code after merging.
Changes only made to `oreo.py`